### PR TITLE
NOJIRA-Fix-general-bugs

### DIFF
--- a/pkg/collector/bridge.go
+++ b/pkg/collector/bridge.go
@@ -53,7 +53,8 @@ func (h *collector) bridgeCollects() error {
 		promBridgeDuration.WithLabelValues(bridge.Type, bridge.Technology).Observe(bridge.Duration)
 	}
 
-	// set count
+	// reset gauge to clear stale label combinations, then set current values
+	promCurrentBridgeCount.Reset()
 	for bridgeType, tmp := range mapBridgeCount {
 		for bridgeTech, bridgeCount := range tmp {
 			promCurrentBridgeCount.WithLabelValues(bridgeType, bridgeTech).Set(float64(bridgeCount))
@@ -80,7 +81,7 @@ func (h *collector) bridgeParser(data string) []bridge.Bridge {
 		}
 
 		items := strings.Fields(dataline)
-		if len(items) < 2 {
+		if len(items) <= idxBridgeDuration {
 			continue
 		}
 

--- a/pkg/collector/bridge_test.go
+++ b/pkg/collector/bridge_test.go
@@ -116,3 +116,81 @@ func Test_bridgeParser(t *testing.T) {
 		})
 	}
 }
+
+func Test_bridgeParser_malformed(t *testing.T) {
+
+	tests := []struct {
+		name          string
+		data          string
+		expectedCount int
+	}{
+		{
+			"empty input",
+			``,
+			0,
+		},
+		{
+			"header only",
+			`Bridge-ID                            Chans Type            Technology      Duration`,
+			0,
+		},
+		{
+			"too few fields",
+			`Bridge-ID                            Chans Type            Technology      Duration
+008e2905-1aa7-4106-b388-3e3f5c157265     0 stasis`,
+			0,
+		},
+		{
+			"4 fields instead of 5",
+			`Bridge-ID                            Chans Type            Technology      Duration
+008e2905-1aa7-4106-b388-3e3f5c157265     0 stasis          simple_bridge`,
+			0,
+		},
+		{
+			"mixed valid and malformed lines",
+			`Bridge-ID                            Chans Type            Technology      Duration
+008e2905-1aa7-4106-b388-3e3f5c157265     0 stasis          simple_bridge   220:34:45
+incomplete line
+010d3e2d-282b-422c-a07d-4d440d4bb3c6     0 stasis          simple_bridge   221:46:48`,
+			2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &collector{}
+
+			res := h.bridgeParser(tt.data)
+			if len(res) != tt.expectedCount {
+				t.Errorf("Expected %d parsed bridges, got %d", tt.expectedCount, len(res))
+			}
+		})
+	}
+}
+
+func Test_bridgeParser_mixed(t *testing.T) {
+
+	h := &collector{}
+
+	data := `Bridge-ID                            Chans Type            Technology      Duration
+008e2905-1aa7-4106-b388-3e3f5c157265     0 stasis          simple_bridge   220:34:45
+incomplete line
+010d3e2d-282b-422c-a07d-4d440d4bb3c6     0 stasis          simple_bridge   221:46:48`
+
+	res := h.bridgeParser(data)
+	if len(res) != 2 {
+		t.Fatalf("Expected 2 parsed bridges, got %d", len(res))
+	}
+	if res[0].ID != "008e2905-1aa7-4106-b388-3e3f5c157265" {
+		t.Errorf("Expected first bridge ID 008e2905-1aa7-4106-b388-3e3f5c157265, got %s", res[0].ID)
+	}
+	if res[0].Duration != 794085 {
+		t.Errorf("Expected first bridge duration 794085, got %f", res[0].Duration)
+	}
+	if res[1].ID != "010d3e2d-282b-422c-a07d-4d440d4bb3c6" {
+		t.Errorf("Expected second bridge ID 010d3e2d-282b-422c-a07d-4d440d4bb3c6, got %s", res[1].ID)
+	}
+	if res[1].Duration != 798408 {
+		t.Errorf("Expected second bridge duration 798408, got %f", res[1].Duration)
+	}
+}

--- a/pkg/collector/channel.go
+++ b/pkg/collector/channel.go
@@ -63,7 +63,9 @@ func (h *collector) channelCollects() error {
 		promChannelDuration.WithLabelValues(tech, channel.Context).Observe(float64(channel.CallDuration))
 	}
 
-	// set metrics
+	// reset gauges to clear stale label combinations, then set current values
+	promCurrentChannelTech.Reset()
+	promCurrentChannelContext.Reset()
 	for k, v := range channelTech {
 		promCurrentChannelTech.WithLabelValues(k).Set(float64(v))
 	}
@@ -97,7 +99,7 @@ func (h *collector) channelParser(data string) []*channel.Channel {
 	datalines := strings.Split(string(data), "\n")
 	for _, dataline := range datalines {
 		items := strings.Split(dataline, "!")
-		if len(items) < 2 {
+		if len(items) <= idxChannelUniqueID {
 			continue
 		}
 

--- a/pkg/collector/channel_test.go
+++ b/pkg/collector/channel_test.go
@@ -94,8 +94,79 @@ PJSIP/call-in-0000060f!call-in!+821100000005!8!Up!Stasis!voipbin,context=call-in
 
 			res := h.channelParser(tt.data)
 			if !reflect.DeepEqual(res, tt.expectRes) {
-				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.expectRes[0], res[0])
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.expectRes, res)
 			}
 		})
+	}
+}
+
+func Test_channelParser_malformed(t *testing.T) {
+
+	tests := []struct {
+		name          string
+		data          string
+		expectedCount int
+	}{
+		{
+			"empty input",
+			``,
+			0,
+		},
+		{
+			"only newlines",
+			"\n\n\n",
+			0,
+		},
+		{
+			"too few fields",
+			`PJSIP/test!call-in`,
+			0,
+		},
+		{
+			"13 fields instead of 14",
+			`PJSIP/test!call-in!+821100000005!8!Up!Stasis!data!test11!!!3!47!bridge-id`,
+			0,
+		},
+		{
+			"mixed valid and malformed lines",
+			`PJSIP/test!call-in
+PJSIP/call-in-0000060e!call-in!+821100000005!8!Up!Stasis!voipbin,context=call-in,domain=pstn.voipbin.net,source=211.200.20.28!test11!!!3!47!5b20bec1-14a3-4b71-b3e1-7ed4d290b244!asterisk-call-6f58d55c9c-mdqhx-1656228434.2944
+incomplete!line`,
+			1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &collector{}
+
+			res := h.channelParser(tt.data)
+			if len(res) != tt.expectedCount {
+				t.Errorf("Expected %d parsed channels, got %d", tt.expectedCount, len(res))
+			}
+		})
+	}
+}
+
+func Test_channelParser_mixed(t *testing.T) {
+
+	h := &collector{}
+
+	data := `PJSIP/test!call-in
+PJSIP/call-in-0000060e!call-in!+821100000005!8!Up!Stasis!voipbin,context=call-in,domain=pstn.voipbin.net,source=211.200.20.28!test11!!!3!47!5b20bec1-14a3-4b71-b3e1-7ed4d290b244!asterisk-call-6f58d55c9c-mdqhx-1656228434.2944
+incomplete!line`
+
+	res := h.channelParser(data)
+	if len(res) != 1 {
+		t.Fatalf("Expected 1 parsed channel, got %d", len(res))
+	}
+	if res[0].Name != "PJSIP/call-in-0000060e" {
+		t.Errorf("Expected channel name PJSIP/call-in-0000060e, got %s", res[0].Name)
+	}
+	if res[0].CallDuration != 47 {
+		t.Errorf("Expected call duration 47, got %d", res[0].CallDuration)
+	}
+	if res[0].UniqueID != "asterisk-call-6f58d55c9c-mdqhx-1656228434.2944" {
+		t.Errorf("Expected unique ID asterisk-call-6f58d55c9c-mdqhx-1656228434.2944, got %s", res[0].UniqueID)
 	}
 }


### PR DESCRIPTION
Fix critical parser bounds checks and gauge metric staleness to prevent
runtime panics and stale Prometheus metrics.

- asterisk-exporter: Fix channel parser bounds check to require all 14 fields instead of 2, preventing index-out-of-bounds panic on malformed input
- asterisk-exporter: Fix bridge parser bounds check to require all 5 fields instead of 2, preventing index-out-of-bounds panic on malformed input
- asterisk-exporter: Reset channel tech/context gauges before each collection cycle to clear stale label combinations
- asterisk-exporter: Reset bridge count gauge before each collection cycle to clear stale label combinations
- asterisk-exporter: Add channel parser tests for empty input, insufficient fields, and mixed valid/malformed lines
- asterisk-exporter: Add bridge parser tests for empty input, header-only, insufficient fields, and mixed valid/malformed lines
- asterisk-exporter: Add content verification tests for mixed-input scenarios to confirm correct records are parsed
- asterisk-exporter: Fix existing test error format to show full result instead of only first element