### PR TITLE
NOJIRA-Fix-high-severity-issues

### DIFF
--- a/cmd/asterisk-exporter/main.go
+++ b/cmd/asterisk-exporter/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 // args
-var webListenAddress = flag.String("web_listen_address", ":9495", "Address to listen on for web interface and telemetry.")
+var webListenAddress = flag.String("web_listen_address", "127.0.0.1:9495", "Address to listen on for web interface and telemetry.")
 var webListenPath = flag.String("web_listen_path", "/metrics", "Path under which to expose metrics.")
 
 var asteriskMetricInterval = flag.Int("asterisk_metric_interval", 5, "Interval sec for metric getting")

--- a/pkg/collector/bridge.go
+++ b/pkg/collector/bridge.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -31,7 +32,10 @@ func (h *collector) bridgeCollects() error {
 		"func": "bridgeCollects",
 	})
 
-	res, err := exec.Command("asterisk", "-rx", `bridge show all`).Output()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	res, err := exec.CommandContext(ctx, "asterisk", "-rx", `bridge show all`).Output()
 	if err != nil {
 		log.Errorf("Could not execute asterisk command. err: %v", err)
 		return err
@@ -41,17 +45,30 @@ func (h *collector) bridgeCollects() error {
 
 	// type:tech:count
 	mapBridgeCount := map[string]map[string]int{}
+	currentBridges := map[string]bridgeSnapshot{}
 
-	for _, bridge := range bridges {
-		_, ok := mapBridgeCount[bridge.Type]
+	for _, b := range bridges {
+		_, ok := mapBridgeCount[b.Type]
 		if !ok {
-			mapBridgeCount[bridge.Type] = map[string]int{}
+			mapBridgeCount[b.Type] = map[string]int{}
 		}
 
-		mapBridgeCount[bridge.Type][bridge.Technology]++
+		mapBridgeCount[b.Type][b.Technology]++
 
-		promBridgeDuration.WithLabelValues(bridge.Type, bridge.Technology).Observe(bridge.Duration)
+		currentBridges[b.ID] = bridgeSnapshot{
+			bridgeType: b.Type,
+			tech:       b.Technology,
+			duration:   b.Duration,
+		}
 	}
+
+	// observe duration for bridges that disappeared (ended) since last cycle
+	for id, prev := range h.prevBridges {
+		if _, exists := currentBridges[id]; !exists {
+			promBridgeDuration.WithLabelValues(prev.bridgeType, prev.tech).Observe(prev.duration)
+		}
+	}
+	h.prevBridges = currentBridges
 
 	// reset gauge to clear stale label combinations, then set current values
 	promCurrentBridgeCount.Reset()

--- a/pkg/collector/channel.go
+++ b/pkg/collector/channel.go
@@ -1,9 +1,11 @@
 package collector
 
 import (
+	"context"
 	"os/exec"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -41,7 +43,10 @@ func (h *collector) channelCollects() error {
 		"func": "channelCollects",
 	})
 
-	res, err := exec.Command("asterisk", "-rx", `core show channels concise`).Output()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	res, err := exec.CommandContext(ctx, "asterisk", "-rx", `core show channels concise`).Output()
 	if err != nil {
 		log.Errorf("Could not execute the asterisk command. err: %v", err)
 		return err
@@ -51,17 +56,27 @@ func (h *collector) channelCollects() error {
 
 	channelTech := map[string]int{}    // channel tech: count
 	channelContext := map[string]int{} // channel context: count
+	currentChannels := map[string]channelSnapshot{}
 
 	for _, channel := range channels {
-		// tech
 		tech := getTech(channel.Name)
 		channelTech[tech]++
-
-		// channel context
 		channelContext[channel.Context]++
 
-		promChannelDuration.WithLabelValues(tech, channel.Context).Observe(float64(channel.CallDuration))
+		currentChannels[channel.UniqueID] = channelSnapshot{
+			tech:     tech,
+			context:  channel.Context,
+			duration: channel.CallDuration,
+		}
 	}
+
+	// observe duration for channels that disappeared (ended) since last cycle
+	for id, prev := range h.prevChannels {
+		if _, exists := currentChannels[id]; !exists {
+			promChannelDuration.WithLabelValues(prev.tech, prev.context).Observe(float64(prev.duration))
+		}
+	}
+	h.prevChannels = currentChannels
 
 	// reset gauges to clear stale label combinations, then set current values
 	promCurrentChannelTech.Reset()

--- a/pkg/collector/main.go
+++ b/pkg/collector/main.go
@@ -34,6 +34,8 @@ type collector struct {
 func NewCollector(interval int) Collector {
 	h := &collector{
 		MetricInterval: interval,
+		prevChannels:   map[string]channelSnapshot{},
+		prevBridges:    map[string]bridgeSnapshot{},
 	}
 
 	return h

--- a/pkg/collector/main.go
+++ b/pkg/collector/main.go
@@ -12,8 +12,22 @@ type Collector interface {
 	Run()
 }
 
+type channelSnapshot struct {
+	tech    string
+	context string
+	duration int
+}
+
+type bridgeSnapshot struct {
+	bridgeType string
+	tech       string
+	duration   float64
+}
+
 type collector struct {
 	MetricInterval int
+	prevChannels   map[string]channelSnapshot
+	prevBridges    map[string]bridgeSnapshot
 }
 
 // NewCollector returns a new Collector


### PR DESCRIPTION
Fix three high severity issues: exec.Command calls with no timeout, histogram misuse producing meaningless distributions, and HTTP server binding to all interfaces by default.

- asterisk-exporter: Add 30s timeout to exec.Command calls via CommandContext to prevent hung Asterisk CLI from blocking the collector forever
- asterisk-exporter: Fix histogram misuse by tracking entity IDs between cycles and observing duration only when entities disappear (end), producing meaningful completion-time distributions
- asterisk-exporter: Change default listen address from :9495 to 127.0.0.1:9495 to avoid exposing metrics to the entire network