### PR TITLE
NOJIRA-Bump-version-to-0.0.5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Prometheus metrics exporter for Asterisk PBX. Polls Asterisk via CLI commands (`
 # Build for all platforms (linux/windows/macos)
 make build
 
-# Build output: asterisk-exporter-0.0.2-{os}-{arch}
+# Build output: asterisk-exporter-0.0.5-{os}-{arch}
 # Cross-compile targets defined in build.sh
 
 # Run tests
@@ -25,7 +25,7 @@ go test -v ./pkg/collector/...
 go test -v -run TestChannelParser ./pkg/collector/...
 
 # Run the binary
-./asterisk-exporter-0.0.2-linux-amd64 -web_listen_address=":9495" -asterisk_metric_interval=5
+./asterisk-exporter-0.0.5-linux-amd64 -web_listen_address=":9495" -asterisk_metric_interval=5
 ```
 
 ## Architecture

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 TARGET = asterisk-exporter
-VERSION = 0.0.2
+VERSION = 0.0.5
 
 TARGET_RELEASE = $(TARGET)-$(VERSION)
 


### PR DESCRIPTION
Bump version to 0.0.5 in preparation for new release tag.

- asterisk-exporter: Update Makefile VERSION from 0.0.2 to 0.0.5
- asterisk-exporter: Update CLAUDE.md version references to 0.0.5