### PR TITLE
NOJIRA-Rewrite-README-for-new-users

### DIFF
--- a/docs/plans/2026-02-20-readme-rewrite-design.md
+++ b/docs/plans/2026-02-20-readme-rewrite-design.md
@@ -1,0 +1,40 @@
+# README Rewrite Design
+
+## Goal
+
+Rewrite the README to follow standard Prometheus exporter conventions, making it useful for new users discovering the project.
+
+## Approach
+
+Standard Prometheus exporter README (matching conventions of node_exporter, mysqld_exporter, etc.): reference-oriented, single file, concise.
+
+## Sections
+
+1. **Title + Description** — One-liner: Prometheus exporter for Asterisk PBX. Polls via CLI, exposes channel/bridge metrics. Tested with Asterisk 18.
+
+2. **Prerequisites** — Go 1.24+, Asterisk (tested with 18). Note the exporter must run on the same host as Asterisk since it calls `asterisk -rx` directly.
+
+3. **Build** — `make build` cross-compiles for linux/windows/darwin. Note output binary naming convention.
+
+4. **Usage** — Updated flag reference with version 0.0.5, correct default address `127.0.0.1:9495`. Basic run command example.
+
+5. **Metrics** — Table format: metric name, type (gauge/histogram/counter), description. Grouped by health, channel, bridge.
+
+6. **Example Output** — Trimmed `curl` example showing only asterisk-specific metrics (drop go runtime metrics).
+
+7. **License** — One line pointing to LICENSE file.
+
+## What Changes
+
+- Fix version from 0.0.1 to 0.0.5
+- Fix default listen address from `:9495` to `127.0.0.1:9495`
+- Add prerequisites section
+- Add build instructions
+- Convert metrics list to table format
+- Trim example output to relevant metrics only
+- Add license reference
+
+## What Stays the Same
+
+- Metric names (including intentional `crruent` typo) are documented as-is
+- Same example metrics output content (just trimmed)

--- a/docs/plans/2026-02-20-readme-rewrite.md
+++ b/docs/plans/2026-02-20-readme-rewrite.md
@@ -1,3 +1,25 @@
+# README Rewrite Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Rewrite the README to follow standard Prometheus exporter conventions for new users.
+
+**Architecture:** Single file replacement. No code changes, no new files beyond README.md itself.
+
+**Tech Stack:** Markdown
+
+---
+
+### Task 1: Rewrite README.md
+
+**Files:**
+- Modify: `README.md`
+
+**Step 1: Replace README.md with the new content**
+
+Write the following complete content to `README.md`:
+
+```markdown
 # asterisk-exporter
 
 Prometheus metrics exporter for Asterisk PBX. Polls Asterisk via CLI commands (`asterisk -rx`) and exposes channel and bridge metrics on an HTTP endpoint.
@@ -103,3 +125,24 @@ asterisk_health_fail{} 0
 ## License
 
 MIT License. See [LICENSE](LICENSE).
+```
+
+**Step 2: Verify the README renders correctly**
+
+Run: `cat README.md | head -5`
+Expected: Title and description lines appear correctly.
+
+**Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "Rewrite README for new users
+
+- asterisk-exporter: Restructure README to follow Prometheus exporter conventions
+- asterisk-exporter: Fix version from 0.0.1 to 0.0.5
+- asterisk-exporter: Fix default listen address to 127.0.0.1:9495
+- asterisk-exporter: Add prerequisites and build sections
+- asterisk-exporter: Convert metrics list to table format with labels
+- asterisk-exporter: Trim example output to asterisk-specific metrics only
+- asterisk-exporter: Add license reference"
+```


### PR DESCRIPTION
Rewrite README to follow standard Prometheus exporter conventions, making it
useful for new users discovering the project.

- asterisk-exporter: Restructure README to follow Prometheus exporter conventions
- asterisk-exporter: Fix version from 0.0.1 to 0.0.5
- asterisk-exporter: Fix default listen address to 127.0.0.1:9495
- asterisk-exporter: Add prerequisites and build sections
- asterisk-exporter: Convert metrics list to table format with labels
- asterisk-exporter: Trim example output to asterisk-specific metrics only
- asterisk-exporter: Add license reference